### PR TITLE
DCT-37493 Update to upgrade underscorejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "backbone": "1.3.3",
     "jquery": "3.5.1",
     "jquery-ui": "1.12.1",
-    "underscore": "1.4.3"
+    "underscore": "1.12.1"
   },
   "engines": {
     "yarn": ">= 1.0.0"


### PR DESCRIPTION
Update to upgrade the version of underscorejs to 1.12.1 to avoid the security issue.
CVE link : https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23358
Changelog : https://underscorejs.org/#changelog
